### PR TITLE
Add support for e2e test filenames

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3103,7 +3103,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'testts',
       extensions: [],
-      filenamesGlob: ['test', 'spec'],
+      filenamesGlob: ['test', 'spec', 'e2e-test', 'e2e-spec'],
       extensionsGlob: ['ts', 'tsx'],
       format: FileFormat.svg,
     },


### PR DESCRIPTION
_**Fixes #2022**_

**Changes proposed:**

Trying to add support for the `.e2e-spec.ts, .e2e-test.ts` files
Exploring the code. I found the extension file. This applies to all `ts` files, I do not know if this completely solves the problem. I await your review.

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
